### PR TITLE
Fix "extraneous bytes" error

### DIFF
--- a/backend/views/opencv_video_view.py
+++ b/backend/views/opencv_video_view.py
@@ -56,7 +56,14 @@ class OpenCVVideoView(BaseVideoView):
             else:
                 # Handle different frame formats
                 if frame.format == "jpeg":
-                    arr = np.frombuffer(frame.data, dtype=np.uint8)
+                    # wrap in a file‐like buffer
+                    frame_buffer = io.BytesIO(frame.data)
+                    clean_buffer = io.BytesIO()
+                    with Image.open(frame_buffer) as clean_img:
+                        clean_img.save(clean_buffer, format="JPEG")
+                    clean_buffer.seek(0)
+                    clean_bytes = clean_buffer.read()
+                    arr = np.frombuffer(clean_bytes, dtype=np.uint8)
                     decoded = cv2.imdecode(arr, cv2.IMREAD_COLOR)
                     if decoded is None:
                         print(f"[display] ⚠ imdecode failed ({len(arr)} bytes)")


### PR DESCRIPTION
This hack fixes the "Corrupt JPEG data: [x] extraneous bytes before marker 0xd9" error that gets thrown by imdecode. We open it using Pillow first, then just save it back to a new buffer to "clean" it, then load the clean bytes into imdecode.

Performance seems fine but there may be a better solution to this if we can figure out why the jpeg data is "corrupt" in the first place. Might just need to compare in hex editor. But this cleans up log for now.