### PR TITLE
Better reconnection logic for WiFi UAV impl

### DIFF
--- a/backend/protocols/wifi_uav_video_protocol.py
+++ b/backend/protocols/wifi_uav_video_protocol.py
@@ -27,8 +27,8 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
     REQUEST_A_OFFSETS = (12, 13)          # two-byte LE frame counter
     REQUEST_B_OFFSETS = (12, 13, 88, 89, 107, 108)
 
-    FRAME_TIMEOUT = 0.15          # 150 ms without a full frame → retry
-    MAX_RETRIES = 1              # after this we skip the frame
+    FRAME_TIMEOUT = 0.10          # 150 ms without a full frame → retry
+    MAX_RETRIES = 2              # after this we skip the frame
     WATCHDOG_SLEEP = 0.05          # 50 ms between watchdog checks
 
     # ------------------------------------------------------------------ #

--- a/backend/web_server.py
+++ b/backend/web_server.py
@@ -90,11 +90,15 @@ async def lifespan(app: FastAPI):
         raise ValueError(f"Unknown drone type: {drone_type}")
 
     # 1. Video – let the service create / recycle the adapter
-    receiver = VideoReceiverService(
-        video_adapter_cls,
-        video_adapter_args,
-        RAW_Q,
-    )
+    video_service_args = {
+        "protocol_adapter_class": video_adapter_cls,
+        "protocol_adapter_args": video_adapter_args,
+        "frame_queue": RAW_Q,
+    }
+    if drone_type == "wifi_uav":
+        video_service_args["rc_adapter"] = rc_proto
+    
+    receiver = VideoReceiverService(**video_service_args)
     receiver.start()
 
     # Wait a moment for video to stabilize


### PR DESCRIPTION
WiFi UAV impl needs special reconnection logic because it uses one shared socket for both rc and video feed.