### PR TITLE
WiFi UAV Fixes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -26,6 +26,7 @@ from protocols.cooingdv_video_protocol import CooingdvVideoProtocolAdapter
 
 from services.flight_controller import FlightController
 from services.video_receiver import VideoReceiverService
+from utils.wifi_uav_variants import WIFI_UAV_DRONE_TYPES, resolve_wifi_uav_variant
 from views.cli_rc import CLIView
 from views.opencv_video_view import OpenCVVideoView
 
@@ -36,8 +37,8 @@ logger = logging.getLogger(__name__)
 def main():
     parser = argparse.ArgumentParser(description="Drone teleoperation interface")
     parser.add_argument("--drone-type", type=str, default="s2x", 
-                        choices=["s2x", "wifi_uav", "cooingdv"],
-                        help="Type of drone to control (s2x, wifi_uav, or cooingdv, default: s2x)")
+                        choices=["s2x", "wifi_uav", "wifi_uav_fld", "wifi_uav_uav", "cooingdv"],
+                        help="Type of drone to control (s2x, wifi_uav, wifi_uav_fld, wifi_uav_uav, or cooingdv, default: s2x)")
     parser.add_argument("--drone-ip", type=str,
                         help="Drone UDP IP address (default: s2x=172.16.10.1, wifi_uav=192.168.169.1, cooingdv=192.168.1.1)")
     parser.add_argument("--control-port", type=int,
@@ -69,8 +70,9 @@ def main():
         drone_model = S2xDroneModel()
         protocol_adapter = S2xRCProtocolAdapter(drone_ip, control_port)
         video_protocol_adapter_class = S2xVideoProtocolAdapter
-    elif args.drone_type == "wifi_uav":
-        logger.info("[main] Using WiFi UAV drone implementation.")
+    elif args.drone_type in WIFI_UAV_DRONE_TYPES:
+        wifi_uav_variant = resolve_wifi_uav_variant(args.drone_type)
+        logger.info("[main] Using WiFi UAV drone implementation (variant=%s).", wifi_uav_variant)
         default_ip = "192.168.169.1"
         default_control_port = 8800
         default_video_port = 8800 # For WifiUAV, control and video often use the same port
@@ -81,7 +83,7 @@ def main():
         video_port = args.video_port if args.video_port else default_video_port
 
         drone_model = WifiUavRcModel()
-        protocol_adapter = WifiUavRcProtocolAdapter(drone_ip, control_port)
+        protocol_adapter = WifiUavRcProtocolAdapter(drone_ip, control_port, variant=wifi_uav_variant)
         video_protocol_adapter_class = WifiUavVideoProtocolAdapter
     elif args.drone_type == "cooingdv":
         logger.info("[main] Using Cooingdv drone implementation (RC UFO, KY UFO, E88 Pro).")
@@ -121,11 +123,12 @@ def main():
                 "control_port": control_port,
                 "video_port": video_port
             }
-        elif args.drone_type == "wifi_uav":
+        elif args.drone_type in WIFI_UAV_DRONE_TYPES:
             video_protocol_args = {
                 "drone_ip": drone_ip,
                 "control_port": control_port,
-                "video_port": video_port
+                "video_port": video_port,
+                "variant": wifi_uav_variant,
             }
         elif args.drone_type == "cooingdv":
             video_protocol_args = {
@@ -140,7 +143,8 @@ def main():
             video_protocol_args,          # The arguments for it
             frame_queue,
             dump_frames=args.dump_frames,
-            dump_packets=args.dump_packets
+            dump_packets=args.dump_packets,
+            rc_adapter=protocol_adapter if args.drone_type in WIFI_UAV_DRONE_TYPES else None,
         )
         video_view = OpenCVVideoView(frame_queue)
         

--- a/backend/protocols/wifi_uav_rc_protocol_adapter.py
+++ b/backend/protocols/wifi_uav_rc_protocol_adapter.py
@@ -50,9 +50,12 @@ class WifiUavRcProtocolAdapter(BaseProtocolAdapter):
     def __init__(self,
                  drone_ip: str = DEFAULT_DRONE_IP,
                  control_port: int = DEFAULT_PORT,
-                 shared_sock: Optional[socket.socket] = None) -> None:
+                 shared_sock: Optional[socket.socket] = None,
+                 variant: str = "auto") -> None:
         self.drone_ip = drone_ip
         self.control_port = control_port
+        self.variant = (variant or "auto").strip().lower()
+        self._target_ports = self._resolve_target_ports(control_port)
 
         self.sock = shared_sock or socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._is_shared_sock = shared_sock is not None
@@ -157,7 +160,8 @@ class WifiUavRcProtocolAdapter(BaseProtocolAdapter):
         hands us the fresh socket.
         """
         try:
-            self.sock.sendto(packet, (self.drone_ip, self.control_port))
+            for port in self._target_ports:
+                self.sock.sendto(packet, (self.drone_ip, port))
         except OSError:
             # Socket was closed during video-reconnect window.
             # Wait for VideoReceiverService to call set_socket(…) with the
@@ -193,3 +197,8 @@ class WifiUavRcProtocolAdapter(BaseProtocolAdapter):
         state = "ON" if self.debug_packets else "OFF"
         print(f"[wifi-uav] debug {state}")
         return self.debug_packets
+
+    def _resolve_target_ports(self, control_port: int) -> tuple[int, ...]:
+        if self.variant == "uav":
+            return (control_port, control_port + 1)
+        return (control_port,)

--- a/backend/protocols/wifi_uav_rc_protocol_adapter.py
+++ b/backend/protocols/wifi_uav_rc_protocol_adapter.py
@@ -10,9 +10,9 @@ class WifiUavRcProtocolAdapter(BaseProtocolAdapter):
     Builds and transmits control packets for the WiFi-UAV family.
     Packet layout derived from reverse-engineered Android app traces.
 
-    The decompiled WiFi-UAV app exposes separate land and emergency-stop
-    controls. We preserve that distinction in the command byte here instead of
-    collapsing both actions into the same value.
+    Turbodrone uses the extended WiFi-UAV command layout (`66 14 ...`). In
+    that layout the app maps takeoff and land onto the same one-key action bit,
+    while emergency stop is a separate bit.
     """
 
     DEFAULT_DRONE_IP: Final = "192.168.169.1"
@@ -41,10 +41,9 @@ class WifiUavRcProtocolAdapter(BaseProtocolAdapter):
         0x00, 0x00
     ])
 
-    FLAG_TAKEOFF = 0x01
-    FLAG_LAND = 0x02
-    FLAG_STOP = 0x04
-    FLAG_CALIBRATION = 0x80
+    FLAG_TAKEOFF_OR_LAND = 0x01
+    FLAG_STOP = 0x02
+    FLAG_CALIBRATION = 0x04
 
     # ------------------------------------------------------------------ #
     def __init__(self,
@@ -100,10 +99,18 @@ class WifiUavRcProtocolAdapter(BaseProtocolAdapter):
 
         # ----- command / headless --------------------------------------
         command = 0x00
-        if drone_model.takeoff_flag:
-            command |= self.FLAG_TAKEOFF
+        if drone_model.takeoff_flag or drone_model.land_flag:
+            command |= self.FLAG_TAKEOFF_OR_LAND
         if drone_model.land_flag:
-            command |= self.FLAG_LAND
+            self._last_command_intent = "LAND"
+        elif drone_model.takeoff_flag:
+            self._last_command_intent = "TAKEOFF"
+        elif drone_model.stop_flag:
+            self._last_command_intent = "STOP"
+        elif drone_model.calibration_flag:
+            self._last_command_intent = "CALIBRATE"
+        else:
+            self._last_command_intent = None
         if drone_model.stop_flag:
             command |= self.FLAG_STOP
         if drone_model.calibration_flag:
@@ -179,10 +186,8 @@ class WifiUavRcProtocolAdapter(BaseProtocolAdapter):
                 command = getattr(self, "_last_command", None)
                 if command is not None:
                     flags = []
-                    if command & self.FLAG_TAKEOFF:
-                        flags.append("TAKEOFF")
-                    if command & self.FLAG_LAND:
-                        flags.append("LAND")
+                    if command & self.FLAG_TAKEOFF_OR_LAND:
+                        flags.append(getattr(self, "_last_command_intent", None) or "TAKEOFF_OR_LAND")
                     if command & self.FLAG_STOP:
                         flags.append("STOP")
                     if command & self.FLAG_CALIBRATION:

--- a/backend/protocols/wifi_uav_video_protocol.py
+++ b/backend/protocols/wifi_uav_video_protocol.py
@@ -1,3 +1,4 @@
+import logging
 import socket
 import queue
 import threading
@@ -6,8 +7,15 @@ from typing import Dict, Optional
 
 from models.video_frame import VideoFrame
 from protocols.base_video_protocol import BaseVideoProtocolAdapter
-from utils.wifi_uav_packets import START_STREAM, REQUEST_A, REQUEST_B
+from utils.wifi_uav_packets import (
+    START_STREAM,
+    build_ack_slot,
+    build_fragment_ack_bitmap,
+    build_native_ack_packet,
+)
 from utils.wifi_uav_jpeg import generate_jpeg_headers, EOI
+
+logger = logging.getLogger(__name__)
 
 
 class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
@@ -31,6 +39,8 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
     FRAME_TIMEOUT = 0.08          # 80 ms without a full frame → retry sooner
     MAX_RETRIES = 3              # allow one more retry for first-frame reliability
     WATCHDOG_SLEEP = 0.05          # 50 ms between watchdog checks
+    INITIAL_STREAM_TIMEOUT = 8.0  # give warmup some time before forcing restart
+    LINK_STALL_TIMEOUT = 4.0      # no packets for this long -> recreate adapter
 
     # ------------------------------------------------------------------ #
     # life-cycle helpers
@@ -44,15 +54,19 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         jpeg_height: int = 360,
         components: int = 3,
         *,
+        variant: str = "auto",
         debug: bool = False,
     ):
         super().__init__(drone_ip, control_port, video_port)
 
-        self.debug = debug
-        self._dbg = (lambda *a, **k: print(*a, **k)) if debug else (lambda *a, **k: None)
+        self.variant = (variant or "auto").strip().lower()
+        self.debug = debug or logger.isEnabledFor(logging.DEBUG)
+        self._dbg = logger.debug if self.debug else (lambda *a, **k: None)
         self._sock_lock = threading.Lock()
         self._pkt_lock = threading.Lock()
         self._pkt_buffer: list[bytes] = []
+        self._warmup_stop = threading.Event()
+        self._target_ports = self._resolve_target_ports(control_port)
 
         self._sock = self._create_duplex_socket()
 
@@ -63,13 +77,20 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         # If I send 0 it sends 1, starting with 1 is more reliable.
         self._current_fid: int = 1
         self._fragments: Dict[int, bytes] = {}     # frag_id -> payload
+        self._expected_fragments: Optional[int] = None
+        self._pending_ack_frame_id: Optional[int] = None
+        self._pending_ack_fragment_total: Optional[int] = None
+        self._pending_ack_received_fragments: set[int] = set()
         self._last_req_ts = time.time()
         self._last_rx_ts = time.time()
+        self._stream_started = False
 
         # Stats
         self.frames_ok = 0
         self.frames_dropped = 0
         self._dbg(f"[init] adapter ready (control:{control_port}  video:{video_port})")
+        if self.variant == "uav":
+            logger.info("[wifi-uav] UAV/FLOW variant selected; probing UDP ports %s", self._target_ports)
 
         # Kick-off the stream and ask for the first frame
         self.send_start_command()
@@ -109,27 +130,31 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         return self._sock
 
     def send_start_command(self) -> None:
-        self._sock.sendto(START_STREAM, (self.drone_ip, self.control_port))
-        print("[wifi-uav] START_STREAM sent")
+        for port in self._target_ports:
+            self._sock.sendto(START_STREAM, (self.drone_ip, port))
+        self._dbg("[wifi-uav] START_STREAM sent to %s", self._target_ports)
 
     def handle_payload(self, payload: bytes) -> Optional[VideoFrame]:
         """
         Collect slices belonging to the requested frame.
 
-        Packet layout (summarised):
-        byte  1 : must be 0x01 for video
-        bytes 16–17 : little-endian frame counter
-        bytes 32–33 : little-endian fragment counter
-        byte  2 : 0x38 for continuation, ≠0x38 for last fragment
-        bytes 56+ : JPEG payload
+        Native packet layout:
+        byte 0        : 0x93
+        byte 1        : message type; 0x01 means JPEG fragment
+        bytes 2..3    : total packet length
+        bytes 8..15   : image sequence
+        bytes 32..35  : fragment index
+        bytes 36..39  : fragment count
+        bytes 56+     : JPEG payload
         """
-        if len(payload) < 56 or payload[1] != 0x01:
+        parsed = self._parse_fragment_header(payload)
+        if parsed is None:
             return None
 
+        frame_id, frag_id, fragment_total, jpeg_payload = parsed
+        self._stream_started = True
         self._last_rx_ts = time.time()
         self._retry_cnt = 0
-
-        frame_id = int.from_bytes(payload[16:18], "little")
 
         # resynchronise if the drone skipped ahead
         if frame_id != self._current_fid:
@@ -137,18 +162,29 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
             self._dbg(f"⚠ skip   expected {self._current_fid:04x} "
                       f"got {frame_id:04x}")
             self._fragments.clear()
+            self._expected_fragments = None
             self._current_fid = frame_id
 
-        frag_id = int.from_bytes(payload[32:34], "little")
-        self._fragments.setdefault(frag_id, payload[56:])
+        self._expected_fragments = fragment_total
+        self._pending_ack_frame_id = frame_id
+        self._pending_ack_fragment_total = fragment_total
+        self._pending_ack_received_fragments.add(frag_id)
+
+        # Retries can resend a fragment; keep the latest copy so a repaired
+        # fragment can replace an earlier bad or incomplete one.
+        self._fragments[frag_id] = jpeg_payload
         self._dbg(f"← FID:{frame_id:04x} FRAG:{frag_id:04x}")
 
-        # not the last fragment? → wait for more
-        if payload[2] == 0x38:
+        missing = [i for i in range(self._expected_fragments) if i not in self._fragments]
+        if missing:
+            self._dbg(
+                f"⚠ incomplete FID:{frame_id:04x} "
+                f"missing {len(missing)} fragment(s); waiting for retry"
+            )
             return None
 
-        # last fragment – assemble JPEG
-        ordered = [self._fragments[i] for i in sorted(self._fragments)]
+        # Only emit a frame once every fragment up to the announced tail exists.
+        ordered = [self._fragments[i] for i in range(self._expected_fragments)]
         jpeg = self._jpeg_header + b"".join(ordered) + EOI
         frame = VideoFrame(frame_id=frame_id, data=jpeg)
 
@@ -168,8 +204,12 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
 
         # prepare next iteration
         self._fragments.clear()
+        self._expected_fragments = None
+        self._pending_ack_frame_id = None
+        self._pending_ack_fragment_total = None
+        self._pending_ack_received_fragments.clear()
         self._send_frame_request(frame_id)            # ask for next
-        self._current_fid = (frame_id + 1) & 0xFFFF
+        self._current_fid = frame_id + 1
         self._last_rx_ts = self._last_req_ts = time.time()
 
         return frame
@@ -180,29 +220,77 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
     def _warmup_loop(self) -> None:
         """During warmup, periodically resend START_STREAM + frame request
         until the first frame is observed, then exit."""
-        while getattr(self, "_first_frame", False):
+        while getattr(self, "_first_frame", False) and not self._warmup_stop.is_set():
             try:
                 self.send_start_command()
                 # Ask for the previous frame id; the drone will respond with next
                 self._send_frame_request((self._current_fid - 1) & 0xFFFF)
             except Exception:
                 pass
-            time.sleep(0.2)
+            self._warmup_stop.wait(0.2)
     def _send_frame_request(self, frame_id: int) -> None:
-        lo, hi = frame_id & 0xFF, (frame_id >> 8) & 0xFF
+        command_seq = frame_id & 0xFFFFFFFF
 
-        rqst_a = bytearray(REQUEST_A)
-        rqst_a[12], rqst_a[13] = lo, hi
+        rqst_a = build_native_ack_packet(command_seq, [])
+        rqst_b = build_native_ack_packet(command_seq, self._build_ack_slots(frame_id))
 
-        rqst_b = bytearray(REQUEST_B)
-        for base in (12, 88, 107):
-            rqst_b[base] = lo
-            rqst_b[base + 1] = hi
-
-        self._sock.sendto(rqst_a, (self.drone_ip, self.control_port))
-        self._sock.sendto(rqst_b, (self.drone_ip, self.control_port))
+        for port in self._target_ports:
+            self._sock.sendto(rqst_a, (self.drone_ip, port))
+            self._sock.sendto(rqst_b, (self.drone_ip, port))
         self._last_req_ts = time.time()
-        self._dbg(f"→ REQ {frame_id:04x}")
+        self._dbg("→ REQ %04x to %s", frame_id, self._target_ports)
+
+    def _build_ack_slots(self, seq: int) -> list[bytes]:
+        if (
+            self._pending_ack_frame_id is not None
+            and self._pending_ack_fragment_total
+            and self._pending_ack_received_fragments
+        ):
+            bitmap = build_fragment_ack_bitmap(
+                self._pending_ack_fragment_total,
+                self._pending_ack_received_fragments,
+            )
+            return [
+                build_ack_slot(self._pending_ack_frame_id, 0, bitmap),
+                build_ack_slot((self._pending_ack_frame_id + 4) & 0xFFFFFFFFFFFFFFFF, 3),
+            ]
+
+        # Native `build_send_ack()` emits a status=1 slot followed by a status=3
+        # future/request slot in the common steady-state request pattern.
+        return [
+            build_ack_slot(seq, 1, b"\xff\xff\xff\xff"),
+            build_ack_slot(seq, 3),
+        ]
+
+    def _parse_fragment_header(self, payload: bytes) -> Optional[tuple[int, int, int, bytes]]:
+        if len(payload) < 56 or payload[0] != 0x93 or payload[1] != 0x01:
+            return None
+
+        declared_len = int.from_bytes(payload[2:4], "little")
+        native_layout = declared_len == len(payload)
+        if native_layout:
+            frame_id = int.from_bytes(payload[8:16], "little")
+            frag_id = int.from_bytes(payload[32:36], "little")
+            fragment_total = int.from_bytes(payload[36:40], "little")
+            if fragment_total > 0 and frag_id < fragment_total:
+                return frame_id, frag_id, fragment_total, payload[56:]
+
+        # Compatibility fallback for older captures/comments that only used
+        # 16-bit counters and inferred the last fragment from packet length.
+        frame_id = int.from_bytes(payload[16:18], "little")
+        frag_id = int.from_bytes(payload[32:34], "little")
+        fragment_total = frag_id + 1 if payload[2] != 0x38 else frag_id + 2
+        return frame_id, frag_id, fragment_total, payload[56:]
+
+    def _resolve_target_ports(self, control_port: int) -> tuple[int, ...]:
+        """
+        The native UAVSDK starts the legacy backend on 8800 and the BL618
+        backend on 8801. For the explicit UAV/FLOW variant, probe both just as
+        nativeStart() does. The FLD/legacy path keeps the single-port behavior.
+        """
+        if self.variant == "uav":
+            return (control_port, control_port + 1)
+        return (control_port,)
 
     def _create_duplex_socket(self) -> socket.socket:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -267,7 +355,15 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         self._rx_thread.start()
 
     def is_running(self) -> bool:
-        return bool(self._running and getattr(self, "_rx_thread", None) and self._rx_thread.is_alive())
+        rx_thread = getattr(self, "_rx_thread", None)
+        if not (self._running and rx_thread and rx_thread.is_alive()):
+            return False
+
+        now = time.time()
+        if self._stream_started:
+            return (now - self._last_rx_ts) < self.LINK_STALL_TIMEOUT
+
+        return (now - self._last_req_ts) < self.INITIAL_STREAM_TIMEOUT
 
     def get_frame(self, timeout: float = 1.0) -> Optional[VideoFrame]:
         try:
@@ -299,6 +395,17 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
             time.sleep(self.WATCHDOG_SLEEP)
             now = time.time()
 
+            if self._stream_started and now - self._last_rx_ts >= self.LINK_STALL_TIMEOUT:
+                self._dbg("[wifi-uav] link stalled; forcing adapter restart")
+                self._running = False
+                self._first_frame = False
+                self._warmup_stop.set()
+                try:
+                    self._sock.close()
+                except OSError:
+                    pass
+                break
+
             if now - self._last_req_ts < self.FRAME_TIMEOUT:
                 continue                    # still waiting → nothing to do
 
@@ -319,6 +426,7 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
                           f"OK:{self.frames_ok}  DROP:{self.frames_dropped}")
 
                 self._fragments.clear()
+                self._expected_fragments = None
                 self._retry_cnt  = 0
                 self._current_fid = (self._current_fid + 1) & 0xFFFF
                 self._send_frame_request((self._current_fid - 1) & 0xFFFF)
@@ -328,7 +436,11 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         """Gracefully shut down the adapter and its threads."""
         self._dbg(f"Stopping protocol adapter instance...")
         self._running = False
+        self._first_frame = False
+        self._warmup_stop.set()
         try:
+            if self._warmup_thread and self._warmup_thread.is_alive():
+                self._warmup_thread.join(timeout=0.5)
             if self._watchdog and self._watchdog.is_alive():
                 self._watchdog.join(timeout=0.5)
             if hasattr(self, "_rx_thread") and self._rx_thread and self._rx_thread.is_alive():

--- a/backend/protocols/wifi_uav_video_protocol.py
+++ b/backend/protocols/wifi_uav_video_protocol.py
@@ -297,6 +297,7 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
             return
         # Small frame buffer; upstream will drop if slow
         self._frame_q: "queue.Queue[VideoFrame]" = queue.Queue(maxsize=2)
+        self._last_rx_ts = time.time()
         with self._pkt_lock:
             self._pkt_buffer = []
 
@@ -352,7 +353,7 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         if self._stream_started:
             return (now - self._last_rx_ts) < self.LINK_STALL_TIMEOUT
 
-        return (now - self._last_req_ts) < self.INITIAL_STREAM_TIMEOUT
+        return (now - self._last_rx_ts) < self.INITIAL_STREAM_TIMEOUT
 
     def get_frame(self, timeout: float = 1.0) -> Optional[VideoFrame]:
         try:

--- a/backend/protocols/wifi_uav_video_protocol.py
+++ b/backend/protocols/wifi_uav_video_protocol.py
@@ -65,6 +65,8 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         self._pkt_lock = threading.Lock()
         self._pkt_buffer: list[bytes] = []
         self._warmup_stop = threading.Event()
+        self._warmup_thread: Optional[threading.Thread] = None
+        self._rx_thread: Optional[threading.Thread] = None
         self._target_ports = self._resolve_target_ports(control_port)
 
         self._sock = self._create_duplex_socket()
@@ -162,11 +164,18 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         self._dbg(f"← FID:{frame_id:04x} FRAG:{frag_id:04x}")
 
         if slot is None:
-            missing = fragment_total - len(self._ack_state._slot_for_seq(frame_id).received_fragments)
-            self._dbg(
-                f"⚠ incomplete FID:{frame_id:04x} "
-                f"missing {missing} fragment(s); waiting for retry"
-            )
+            received = len(self._ack_state._slot_for_seq(frame_id).received_fragments)
+            if fragment_total > 0:
+                missing = fragment_total - received
+                self._dbg(
+                    f"⚠ incomplete FID:{frame_id:04x} "
+                    f"missing {missing} fragment(s); waiting for retry"
+                )
+            else:
+                self._dbg(
+                    f"⚠ incomplete FID:{frame_id:04x} "
+                    f"received {received} fragment(s); waiting for tail"
+                )
             return None
 
         # Only emit a frame once every fragment up to the announced tail exists.
@@ -243,7 +252,8 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         # 16-bit counters and inferred the last fragment from packet length.
         frame_id = int.from_bytes(payload[16:18], "little")
         frag_id = int.from_bytes(payload[32:34], "little")
-        fragment_total = frag_id + 1 if payload[2] != 0x38 else frag_id + 2
+        # Legacy packets only reveal the total when the tail fragment arrives.
+        fragment_total = frag_id + 1 if payload[2] != 0x38 else 0
         return frame_id, frag_id, fragment_total, 0, 0, payload[56:]
 
     def _resolve_target_ports(self, control_port: int) -> tuple[int, ...]:
@@ -394,7 +404,7 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
             if self._retry_cnt < self.MAX_RETRIES:
                 self._dbg(f"⚠ timeout FID {self._current_fid:04x} – retry "
                           f"({self._retry_cnt +1}/{self.MAX_RETRIES})")
-                self._send_frame_request((self._current_fid - 1) & 0xFFFF)
+                self._send_frame_request(max(0, self._current_fid - 1))
                 self._retry_cnt += 1
                 self.retry_attempts += 1
                 self._had_retry = True
@@ -415,16 +425,16 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         self._running = False
         self._first_frame = False
         self._warmup_stop.set()
+        for thread in (self._warmup_thread, self._watchdog, self._rx_thread):
+            try:
+                if thread and thread.is_alive():
+                    thread.join(timeout=0.5)
+            except Exception as e:
+                self._dbg(f"Ignoring thread shutdown error: {e}")
         try:
-            if self._warmup_thread and self._warmup_thread.is_alive():
-                self._warmup_thread.join(timeout=0.5)
-            if self._watchdog and self._watchdog.is_alive():
-                self._watchdog.join(timeout=0.5)
-            if hasattr(self, "_rx_thread") and self._rx_thread and self._rx_thread.is_alive():
-                self._rx_thread.join(timeout=0.5)
             self._sock.close()
         except Exception as e:
-            self._dbg(f"Ignoring error during shutdown: {e}")
+            self._dbg(f"Ignoring socket shutdown error: {e}")
 
         self._dbg(
             f"[stats] ok:{self.frames_ok}  dropped:{self.frames_dropped}  "

--- a/backend/protocols/wifi_uav_video_protocol.py
+++ b/backend/protocols/wifi_uav_video_protocol.py
@@ -3,14 +3,13 @@ import socket
 import queue
 import threading
 import time
-from typing import Dict, Optional
+from typing import Optional
 
 from models.video_frame import VideoFrame
 from protocols.base_video_protocol import BaseVideoProtocolAdapter
+from utils.wifi_uav_ack_state import WifiUavAckState
 from utils.wifi_uav_packets import (
     START_STREAM,
-    build_ack_slot,
-    build_fragment_ack_bitmap,
     build_native_ack_packet,
 )
 from utils.wifi_uav_jpeg import generate_jpeg_headers, EOI
@@ -76,14 +75,11 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         # State for the current frame being assembled
         # If I send 0 it sends 1, starting with 1 is more reliable.
         self._current_fid: int = 1
-        self._fragments: Dict[int, bytes] = {}     # frag_id -> payload
-        self._expected_fragments: Optional[int] = None
-        self._pending_ack_frame_id: Optional[int] = None
-        self._pending_ack_fragment_total: Optional[int] = None
-        self._pending_ack_received_fragments: set[int] = set()
+        self._ack_state = WifiUavAckState()
         self._last_req_ts = time.time()
         self._last_rx_ts = time.time()
         self._stream_started = False
+        self._started_once = False
 
         # Stats
         self.frames_ok = 0
@@ -91,14 +87,6 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         self._dbg(f"[init] adapter ready (control:{control_port}  video:{video_port})")
         if self.variant == "uav":
             logger.info("[wifi-uav] UAV/FLOW variant selected; probing UDP ports %s", self._target_ports)
-
-        # Kick-off the stream and ask for the first frame
-        self.send_start_command()
-        self._send_frame_request(0) # Request frame 0 to get frame 1
-        # During warmup, resend until we see the first frame
-        self._first_frame = True
-        self._warmup_thread = threading.Thread(target=self._warmup_loop, daemon=True, name="Warmup")
-        self._warmup_thread.start()
 
         # Watchdog for per-frame timeouts
         self._running = True
@@ -151,7 +139,7 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         if parsed is None:
             return None
 
-        frame_id, frag_id, fragment_total, jpeg_payload = parsed
+        frame_id, frag_id, fragment_total, frame_body_len, quality, jpeg_payload = parsed
         self._stream_started = True
         self._last_rx_ts = time.time()
         self._retry_cnt = 0
@@ -161,31 +149,28 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
             self.frames_dropped += 1
             self._dbg(f"⚠ skip   expected {self._current_fid:04x} "
                       f"got {frame_id:04x}")
-            self._fragments.clear()
-            self._expected_fragments = None
             self._current_fid = frame_id
 
-        self._expected_fragments = fragment_total
-        self._pending_ack_frame_id = frame_id
-        self._pending_ack_fragment_total = fragment_total
-        self._pending_ack_received_fragments.add(frag_id)
-
-        # Retries can resend a fragment; keep the latest copy so a repaired
-        # fragment can replace an earlier bad or incomplete one.
-        self._fragments[frag_id] = jpeg_payload
+        slot = self._ack_state.ingest_fragment(
+            frame_id,
+            frag_id,
+            fragment_total,
+            jpeg_payload,
+            frame_body_len=frame_body_len,
+            quality=quality,
+        )
         self._dbg(f"← FID:{frame_id:04x} FRAG:{frag_id:04x}")
 
-        missing = [i for i in range(self._expected_fragments) if i not in self._fragments]
-        if missing:
+        if slot is None:
+            missing = fragment_total - len(self._ack_state._slot_for_seq(frame_id).received_fragments)
             self._dbg(
                 f"⚠ incomplete FID:{frame_id:04x} "
-                f"missing {len(missing)} fragment(s); waiting for retry"
+                f"missing {missing} fragment(s); waiting for retry"
             )
             return None
 
         # Only emit a frame once every fragment up to the announced tail exists.
-        ordered = [self._fragments[i] for i in range(self._expected_fragments)]
-        jpeg = self._jpeg_header + b"".join(ordered) + EOI
+        jpeg = self._jpeg_header + slot.ordered_payload() + EOI
         frame = VideoFrame(frame_id=frame_id, data=jpeg)
 
         self.frames_ok += 1
@@ -199,15 +184,11 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
             self._had_retry = False
         # ──────────────────────────────────────────────────────────────
 
-        self._dbg(f"✓ {frame_id:04x} ({len(self._fragments)} frags)  "
+        self._dbg(f"✓ {frame_id:04x} ({slot.fragment_total} frags)  "
                   f"OK:{self.frames_ok}  DROP:{self.frames_dropped}")
 
         # prepare next iteration
-        self._fragments.clear()
-        self._expected_fragments = None
-        self._pending_ack_frame_id = None
-        self._pending_ack_fragment_total = None
-        self._pending_ack_received_fragments.clear()
+        self._ack_state.mark_delivered(frame_id)
         self._send_frame_request(frame_id)            # ask for next
         self._current_fid = frame_id + 1
         self._last_rx_ts = self._last_req_ts = time.time()
@@ -224,7 +205,7 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
             try:
                 self.send_start_command()
                 # Ask for the previous frame id; the drone will respond with next
-                self._send_frame_request((self._current_fid - 1) & 0xFFFF)
+                self._send_frame_request(max(0, self._current_fid - 1))
             except Exception:
                 pass
             self._warmup_stop.wait(0.2)
@@ -241,28 +222,9 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         self._dbg("→ REQ %04x to %s", frame_id, self._target_ports)
 
     def _build_ack_slots(self, seq: int) -> list[bytes]:
-        if (
-            self._pending_ack_frame_id is not None
-            and self._pending_ack_fragment_total
-            and self._pending_ack_received_fragments
-        ):
-            bitmap = build_fragment_ack_bitmap(
-                self._pending_ack_fragment_total,
-                self._pending_ack_received_fragments,
-            )
-            return [
-                build_ack_slot(self._pending_ack_frame_id, 0, bitmap),
-                build_ack_slot((self._pending_ack_frame_id + 4) & 0xFFFFFFFFFFFFFFFF, 3),
-            ]
+        return self._ack_state.build_ack_slots(seq)
 
-        # Native `build_send_ack()` emits a status=1 slot followed by a status=3
-        # future/request slot in the common steady-state request pattern.
-        return [
-            build_ack_slot(seq, 1, b"\xff\xff\xff\xff"),
-            build_ack_slot(seq, 3),
-        ]
-
-    def _parse_fragment_header(self, payload: bytes) -> Optional[tuple[int, int, int, bytes]]:
+    def _parse_fragment_header(self, payload: bytes) -> Optional[tuple[int, int, int, int, int, bytes]]:
         if len(payload) < 56 or payload[0] != 0x93 or payload[1] != 0x01:
             return None
 
@@ -272,15 +234,17 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
             frame_id = int.from_bytes(payload[8:16], "little")
             frag_id = int.from_bytes(payload[32:36], "little")
             fragment_total = int.from_bytes(payload[36:40], "little")
+            frame_body_len = int.from_bytes(payload[40:44], "little")
+            quality = payload[48]
             if fragment_total > 0 and frag_id < fragment_total:
-                return frame_id, frag_id, fragment_total, payload[56:]
+                return frame_id, frag_id, fragment_total, frame_body_len, quality, payload[56:]
 
         # Compatibility fallback for older captures/comments that only used
         # 16-bit counters and inferred the last fragment from packet length.
         frame_id = int.from_bytes(payload[16:18], "little")
         frag_id = int.from_bytes(payload[32:34], "little")
         fragment_total = frag_id + 1 if payload[2] != 0x38 else frag_id + 2
-        return frame_id, frag_id, fragment_total, payload[56:]
+        return frame_id, frag_id, fragment_total, 0, 0, payload[56:]
 
     def _resolve_target_ports(self, control_port: int) -> tuple[int, ...]:
         """
@@ -354,6 +318,21 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
         self._rx_thread = threading.Thread(target=_rx_loop, daemon=True, name="WifiUavVideoRx")
         self._rx_thread.start()
 
+        if not self._started_once:
+            self._started_once = True
+            # Kick off the stream only after the receiver is already draining
+            # the UDP socket. K417 responds very quickly and can otherwise dump
+            # the first frame burst before the RX loop is active.
+            self.send_start_command()
+            self._send_frame_request(0)
+            self._first_frame = True
+            self._warmup_thread = threading.Thread(
+                target=self._warmup_loop,
+                daemon=True,
+                name="Warmup",
+            )
+            self._warmup_thread.start()
+
     def is_running(self) -> bool:
         rx_thread = getattr(self, "_rx_thread", None)
         if not (self._running and rx_thread and rx_thread.is_alive()):
@@ -424,12 +403,10 @@ class WifiUavVideoProtocolAdapter(BaseVideoProtocolAdapter):
                 self._dbg(f"✗ drop   FID {self._current_fid:04x} "
                           f"(after {self._retry_cnt} retries)  "
                           f"OK:{self.frames_ok}  DROP:{self.frames_dropped}")
-
-                self._fragments.clear()
-                self._expected_fragments = None
+                self._ack_state.mark_dropped(self._current_fid)
                 self._retry_cnt  = 0
-                self._current_fid = (self._current_fid + 1) & 0xFFFF
-                self._send_frame_request((self._current_fid - 1) & 0xFFFF)
+                self._current_fid += 1
+                self._send_frame_request(max(0, self._current_fid - 1))
                 self._had_retry = False
 
     def stop(self) -> None:

--- a/backend/utils/wifi_uav_ack_state.py
+++ b/backend/utils/wifi_uav_ack_state.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from collections import deque
+from typing import Optional
+
+from utils.wifi_uav_packets import build_ack_slot, build_fragment_ack_bitmap
+
+
+SLOT_EMPTY = 0
+SLOT_RECEIVING = 1
+SLOT_COMPLETE = 2
+SLOT_DELIVERED = 3
+SLOT_DROPPED = 4
+
+
+@dataclass
+class WifiUavFrameSlot:
+    """State for one native WiFi-UAV in-flight frame slot."""
+
+    seq: int = 0
+    status: int = SLOT_EMPTY
+    fragment_total: int = 0
+    frame_body_len: int = 0
+    quality: int = 0
+    fragments: dict[int, bytes] = field(default_factory=dict)
+    received_fragments: set[int] = field(default_factory=set)
+
+    def reset(self, seq: int, fragment_total: int, frame_body_len: int, quality: int) -> None:
+        self.seq = seq
+        self.status = SLOT_RECEIVING
+        self.fragment_total = fragment_total
+        self.frame_body_len = frame_body_len
+        self.quality = quality
+        self.fragments.clear()
+        self.received_fragments.clear()
+
+    def ingest(
+        self,
+        fragment_id: int,
+        fragment_total: int,
+        payload: bytes,
+        *,
+        frame_body_len: int = 0,
+        quality: int = 0,
+    ) -> None:
+        if self.status in (SLOT_COMPLETE, SLOT_DELIVERED):
+            return
+
+        if self.status in (SLOT_EMPTY, SLOT_DELIVERED, SLOT_DROPPED):
+            self.fragment_total = fragment_total
+            self.frame_body_len = frame_body_len
+            self.quality = quality
+            self.status = SLOT_RECEIVING
+
+        self.fragments[fragment_id] = payload
+        self.received_fragments.add(fragment_id)
+
+        if self.is_complete():
+            self.status = SLOT_COMPLETE
+
+    def is_complete(self) -> bool:
+        return (
+            self.fragment_total > 0
+            and len(self.received_fragments) == self.fragment_total
+            and all(i in self.fragments for i in range(self.fragment_total))
+        )
+
+    def ordered_payload(self) -> bytes:
+        return b"".join(self.fragments[i] for i in range(self.fragment_total))
+
+    def mark_delivered(self) -> None:
+        self.status = SLOT_DELIVERED
+
+    def mark_dropped(self) -> None:
+        self.status = SLOT_DROPPED
+
+    def ack_status(self) -> int:
+        if self.status == SLOT_RECEIVING:
+            return 0
+        if self.status in (SLOT_COMPLETE, SLOT_DELIVERED):
+            return 1
+        if self.status == SLOT_DROPPED:
+            return 2
+        return 3
+
+    def ack_bitmap(self) -> bytes:
+        if self.status != SLOT_RECEIVING or self.fragment_total <= 0:
+            return b""
+        return build_fragment_ack_bitmap(self.fragment_total, self.received_fragments)
+
+    def ack_slot(self) -> bytes:
+        return build_ack_slot(self.seq, self.ack_status(), self.ack_bitmap())
+
+
+class WifiUavAckState:
+    """
+    Four-slot ACK/frame tracker shaped after native build_send_ack().
+
+    This keeps Turbodrone's delivery behavior simple while giving ACK generation
+    a native-style home that can be evolved independently of socket code.
+    """
+
+    SLOT_COUNT = 4
+
+    def __init__(self) -> None:
+        self.slots = [WifiUavFrameSlot() for _ in range(self.SLOT_COUNT)]
+        self.max_recv_seq = 0
+        self.last_finished = 0
+        self.last_completed_seq: Optional[int] = None
+        self._delivered_history: deque[int] = deque(maxlen=32)
+
+    def reset(self) -> None:
+        for slot in self.slots:
+            slot.seq = 0
+            slot.status = SLOT_EMPTY
+            slot.fragment_total = 0
+            slot.frame_body_len = 0
+            slot.quality = 0
+            slot.fragments.clear()
+            slot.received_fragments.clear()
+        self.max_recv_seq = 0
+        self.last_finished = 0
+        self.last_completed_seq = None
+        self._delivered_history.clear()
+
+    def ingest_fragment(
+        self,
+        seq: int,
+        fragment_id: int,
+        fragment_total: int,
+        payload: bytes,
+        *,
+        frame_body_len: int = 0,
+        quality: int = 0,
+    ) -> Optional[WifiUavFrameSlot]:
+        if seq in self._delivered_history:
+            return None
+
+        slot = self._slot_for_seq(seq)
+        if slot.seq != seq:
+            slot.reset(seq, fragment_total, frame_body_len, quality)
+
+        if fragment_total <= 0 or fragment_id >= fragment_total:
+            return None
+
+        self.max_recv_seq = max(self.max_recv_seq, seq)
+        self.last_finished = seq
+        slot.ingest(fragment_id, fragment_total, payload, frame_body_len=frame_body_len, quality=quality)
+        if slot.is_complete():
+            self.last_completed_seq = seq
+            return slot
+        return None
+
+    def mark_delivered(self, seq: int) -> None:
+        slot = self._find_slot(seq)
+        if slot is not None:
+            slot.mark_delivered()
+        if seq not in self._delivered_history:
+            self._delivered_history.append(seq)
+
+    def mark_dropped(self, seq: int) -> None:
+        slot = self._find_slot(seq)
+        if slot is not None:
+            slot.mark_dropped()
+
+    def build_ack_slots(self, request_seq: int) -> list[bytes]:
+        slots = []
+        for slot in self.slots:
+            if slot.status == SLOT_EMPTY or slot.seq == 0:
+                continue
+            if self.max_recv_seq and self.max_recv_seq - slot.seq >= 5:
+                continue
+            slots.append(slot.ack_slot())
+
+        if slots:
+            return slots
+
+        return [
+            build_ack_slot(request_seq, 1, b"\xff\xff\xff\xff"),
+            build_ack_slot(request_seq, 3),
+        ]
+
+    def _slot_for_seq(self, seq: int) -> WifiUavFrameSlot:
+        return self.slots[(seq + 3) % self.SLOT_COUNT]
+
+    def _find_slot(self, seq: int) -> Optional[WifiUavFrameSlot]:
+        for slot in self.slots:
+            if slot.seq == seq:
+                return slot
+        return None

--- a/backend/utils/wifi_uav_ack_state.py
+++ b/backend/utils/wifi_uav_ack_state.py
@@ -110,7 +110,6 @@ class WifiUavAckState:
     def __init__(self) -> None:
         self.slots = [WifiUavFrameSlot() for _ in range(self.SLOT_COUNT)]
         self.max_recv_seq = 0
-        self.last_finished = 0
         self.last_completed_seq: Optional[int] = None
         self._delivered_history: deque[int] = deque(maxlen=32)
 
@@ -124,7 +123,6 @@ class WifiUavAckState:
             slot.fragments.clear()
             slot.received_fragments.clear()
         self.max_recv_seq = 0
-        self.last_finished = 0
         self.last_completed_seq = None
         self._delivered_history.clear()
 
@@ -149,7 +147,6 @@ class WifiUavAckState:
             return None
 
         self.max_recv_seq = max(self.max_recv_seq, seq)
-        self.last_finished = seq
         slot.ingest(fragment_id, fragment_total, payload, frame_body_len=frame_body_len, quality=quality)
         if slot.is_complete():
             self.last_completed_seq = seq

--- a/backend/utils/wifi_uav_ack_state.py
+++ b/backend/utils/wifi_uav_ack_state.py
@@ -52,6 +52,10 @@ class WifiUavFrameSlot:
             self.frame_body_len = frame_body_len
             self.quality = quality
             self.status = SLOT_RECEIVING
+        elif fragment_total > 0:
+            self.fragment_total = fragment_total
+            self.frame_body_len = frame_body_len
+            self.quality = quality
 
         self.fragments[fragment_id] = payload
         self.received_fragments.add(fragment_id)
@@ -141,7 +145,7 @@ class WifiUavAckState:
         if slot.seq != seq:
             slot.reset(seq, fragment_total, frame_body_len, quality)
 
-        if fragment_total <= 0 or fragment_id >= fragment_total:
+        if fragment_total > 0 and fragment_id >= fragment_total:
             return None
 
         self.max_recv_seq = max(self.max_recv_seq, seq)

--- a/backend/utils/wifi_uav_packets.py
+++ b/backend/utils/wifi_uav_packets.py
@@ -16,8 +16,14 @@ SSID3 = (
     b"\x3d\x33\x3e"
 )
 
-# Both of these are sent for each frame. It's either an ACK that triggers
-# the new frame, or a "request new frame" message.
+# Both of these are sent for each frame. Native `build_send_ack()` builds this
+# same outer packet shape:
+#
+#   ef 02 <len:u16> 02 02 00 01 <ack-count> ...
+#
+# The packet also embeds the latest user command at offset 18. The current
+# constants carry a neutral extended command (`66 14 80 80 80 80 ... 99`) so
+# video can advance even when no RC input has changed.
 REQUEST_A = (
     b"\xef\x02\x58\x00\x02\x02"
     b"\x00\x01\x00\x00\x00\x00\x05\x00\x00\x00\x14\x00\x66\x14\x80\x80"
@@ -30,7 +36,7 @@ REQUEST_A = (
 
 # See previous comment
 REQUEST_B = (
-    b"\xef\x02\x6c\x00\x02\x02"
+    b"\xef\x02\x7c\x00\x02\x02"
     b"\x00\x01\x02\x00\x00\x00\x09\x00\x00\x00\x14\x00\x66\x14\x80\x80"
     b"\x80\x80\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x99"
     b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
@@ -40,3 +46,78 @@ REQUEST_B = (
     b"\x00\x00\xff\xff\xff\xff\x09\x00\x00\x00\x00\x00\x00\x00\x03\x00"
     b"\x00\x00\x10\x00\x00\x00"
 )
+
+# Native ACK packet sequence fields. These are little-endian integer fields, not
+# arbitrary byte offsets:
+# - 12: queued user-command sequence
+# - 88: first ACK slot sequence
+# - 108: second ACK slot sequence
+REQUEST_A_COMMAND_SEQ_OFFSET = 12
+REQUEST_B_COMMAND_SEQ_OFFSET = 12
+REQUEST_B_ACK_SEQ_OFFSETS = (88, 108)
+
+NEUTRAL_EXTENDED_COMMAND = (
+    b"\x66\x14\x80\x80\x80\x80\x00\x02"
+    b"\x00\x00\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x02\x99"
+)
+
+DEFAULT_QUALITY_PARAMS = b"\x32\x4b\x14\x2d\x00"
+
+
+def build_fragment_ack_bitmap(fragment_total: int, received_fragments: set[int]) -> bytes:
+    """Build the native little-endian fragment ACK bitmap."""
+    if fragment_total <= 0:
+        return b""
+
+    word_count = (fragment_total + 31) // 32
+    words = [0] * word_count
+    for fragment_id in received_fragments:
+        if 0 <= fragment_id < fragment_total:
+            words[fragment_id // 32] |= 1 << (fragment_id & 31)
+
+    return b"".join(word.to_bytes(4, "little") for word in words)
+
+
+def build_ack_slot(seq: int, status: int, bitmap: bytes = b"") -> bytes:
+    """Build one native ACK slot record."""
+    record_len = 16 + len(bitmap)
+    return (
+        (seq & 0xFFFFFFFFFFFFFFFF).to_bytes(8, "little")
+        + (status & 0xFFFFFFFF).to_bytes(4, "little")
+        + record_len.to_bytes(4, "little")
+        + bitmap
+    )
+
+
+def build_native_ack_packet(
+    command_seq: int,
+    ack_slots: list[bytes],
+    command: bytes = NEUTRAL_EXTENDED_COMMAND,
+    quality_params: bytes = DEFAULT_QUALITY_PARAMS,
+) -> bytes:
+    """
+    Build a native-shaped WiFi-UAV ACK/request packet.
+
+    This mirrors the header layout emitted by `build_send_ack()` /
+    `build_send_ack_bl618()` in `libuav_lib.so`.
+    """
+    if len(command) > 64:
+        raise ValueError("WiFi-UAV command payload must be <= 64 bytes")
+    if len(quality_params) != 5:
+        raise ValueError("WiFi-UAV quality params must be exactly 5 bytes")
+
+    packet = bytearray()
+    packet += b"\xef\x02\x00\x00"
+    packet += b"\x02\x02\x00\x01"
+    packet += bytes([len(ack_slots) & 0xFF])
+    packet += b"\x00\x00\x00"
+    packet += (command_seq & 0xFFFFFFFF).to_bytes(4, "little")
+    packet += len(command).to_bytes(2, "little")
+    packet += command.ljust(64, b"\x00")
+    packet += quality_params
+    packet += b"\x00"
+    for slot in ack_slots:
+        packet += slot
+    packet[2:4] = len(packet).to_bytes(2, "little")
+    return bytes(packet)

--- a/backend/utils/wifi_uav_packets.py
+++ b/backend/utils/wifi_uav_packets.py
@@ -47,15 +47,6 @@ REQUEST_B = (
     b"\x00\x00\x10\x00\x00\x00"
 )
 
-# Native ACK packet sequence fields. These are little-endian integer fields, not
-# arbitrary byte offsets:
-# - 12: queued user-command sequence
-# - 88: first ACK slot sequence
-# - 108: second ACK slot sequence
-REQUEST_A_COMMAND_SEQ_OFFSET = 12
-REQUEST_B_COMMAND_SEQ_OFFSET = 12
-REQUEST_B_ACK_SEQ_OFFSETS = (88, 108)
-
 NEUTRAL_EXTENDED_COMMAND = (
     b"\x66\x14\x80\x80\x80\x80\x00\x02"
     b"\x00\x00\x00\x00\x00\x00\x00\x00"

--- a/backend/utils/wifi_uav_variants.py
+++ b/backend/utils/wifi_uav_variants.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import Final
+
+
+WIFI_UAV_DRONE_TYPES: Final[frozenset[str]] = frozenset({
+    "wifi_uav",
+    "wifi_uav_fld",
+    "wifi_uav_uav",
+})
+
+_UAV_PREFIXES: Final[tuple[str, ...]] = ("flow_", "flow-", "flow")
+_FLD_PREFIXES: Final[tuple[str, ...]] = ("wifi_", "gd89pro_", "wtech-", "wtech_")
+
+
+def wifi_uav_variant_from_drone_type(drone_type: str) -> str:
+    """Map the user-facing DRONE_TYPE onto the internal wifi_uav variant name."""
+    normalised = (drone_type or "").strip().lower()
+    if normalised == "wifi_uav_fld":
+        return "fld"
+    if normalised == "wifi_uav_uav":
+        return "uav"
+    return "auto"
+
+
+def resolve_wifi_uav_variant(drone_type: str) -> str:
+    """
+    Resolve the effective wifi_uav transport variant.
+
+    Explicit DRONE_TYPE aliases win. For the umbrella `wifi_uav` type, prefer a
+    best-effort SSID-based choice and otherwise fall back to the legacy/default
+    path, which today is closest to the FLD-style transport.
+    """
+    explicit = wifi_uav_variant_from_drone_type(drone_type)
+    if explicit != "auto":
+        return explicit
+
+    ssid = detect_active_wifi_ssid()
+    mapped = map_wifi_uav_variant_from_ssid(ssid)
+    if mapped:
+        return mapped
+
+    return "fld"
+
+
+def map_wifi_uav_variant_from_ssid(ssid: str | None) -> str | None:
+    """Map a Wi-Fi SSID prefix onto the app's Uav/Fld backend choice."""
+    if not ssid:
+        return None
+
+    normalised = ssid.strip().lower()
+    if any(normalised.startswith(prefix) for prefix in _UAV_PREFIXES):
+        return "uav"
+    if any(normalised.startswith(prefix) for prefix in _FLD_PREFIXES):
+        return "fld"
+    return None
+
+
+def detect_active_wifi_ssid() -> str | None:
+    """
+    Best-effort detection of the currently connected Wi-Fi SSID.
+
+    This is intentionally conservative: if platform-specific commands are not
+    available or parsing fails, return None and let the caller fall back.
+    """
+    for env_name in ("WIFI_UAV_SSID", "DRONE_SSID", "WIFI_SSID"):
+        value = os.getenv(env_name, "").strip()
+        if value:
+            return value
+
+    try:
+        if sys.platform.startswith("win"):
+            return _detect_ssid_windows()
+        if sys.platform == "darwin":
+            return _detect_ssid_macos()
+        return _detect_ssid_linux()
+    except Exception:
+        return None
+
+
+def _detect_ssid_windows() -> str | None:
+    result = subprocess.run(
+        ["netsh", "wlan", "show", "interfaces"],
+        capture_output=True,
+        text=True,
+        timeout=2.0,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped.lower().startswith("ssid") or stripped.lower().startswith("bssid"):
+            continue
+        _, _, value = stripped.partition(":")
+        ssid = value.strip()
+        if ssid:
+            return ssid
+    return None
+
+
+def _detect_ssid_macos() -> str | None:
+    airport = "/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport"
+    result = subprocess.run(
+        [airport, "-I"],
+        capture_output=True,
+        text=True,
+        timeout=2.0,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("SSID:"):
+            continue
+        _, _, value = stripped.partition(":")
+        ssid = value.strip()
+        if ssid:
+            return ssid
+    return None
+
+
+def _detect_ssid_linux() -> str | None:
+    for command in (["iwgetid", "-r"], ["nmcli", "-t", "-f", "active,ssid", "dev", "wifi"]):
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+        if result.returncode != 0:
+            continue
+
+        output = result.stdout.strip()
+        if not output:
+            continue
+
+        if command[0] == "nmcli":
+            for line in output.splitlines():
+                if not line.startswith("yes:"):
+                    continue
+                ssid = line.split(":", 1)[1].strip()
+                if ssid:
+                    return ssid
+        else:
+            return output
+
+    return None

--- a/backend/utils/wifi_uav_variants.py
+++ b/backend/utils/wifi_uav_variants.py
@@ -13,7 +13,7 @@ WIFI_UAV_DRONE_TYPES: Final[frozenset[str]] = frozenset({
 })
 
 _UAV_PREFIXES: Final[tuple[str, ...]] = ("flow_", "flow-", "flow")
-_FLD_PREFIXES: Final[tuple[str, ...]] = ("wifi_", "gd89pro_", "wtech-", "wtech_")
+_FLD_PREFIXES: Final[tuple[str, ...]] = ("wifi_", "gd89pro_", "wtech-", "wtech_", "drone_")
 
 
 def wifi_uav_variant_from_drone_type(drone_type: str) -> str:

--- a/backend/web_server.py
+++ b/backend/web_server.py
@@ -31,6 +31,7 @@ from protocols.cooingdv_rc_protocol_adapter import CooingdvRcProtocolAdapter
 from protocols.cooingdv_video_protocol import CooingdvVideoProtocolAdapter
 from plugins.manager import PluginManager
 from utils.dropping_queue import DroppingQueue
+from utils.wifi_uav_variants import WIFI_UAV_DRONE_TYPES, resolve_wifi_uav_variant
 
 
 class ConnectionManager:
@@ -93,7 +94,7 @@ def _control_capabilities_for_drone(drone_type: str) -> dict[str, bool]:
     These capabilities let the frontend keep its control cluster honest instead
     of assuming every implementation supports the same actions.
     """
-    if drone_type in {"s2x", "wifi_uav", "cooingdv"}:
+    if drone_type in {"s2x", "cooingdv"} or drone_type in WIFI_UAV_DRONE_TYPES:
         return {
             "takeoff": True,
             "land": True,
@@ -195,8 +196,9 @@ async def lifespan(app: FastAPI):
             "control_port": ctrl_port,
             "video_port": video_port,
         }
-    elif drone_type == "wifi_uav":
-        logger.info("[main] Using WiFi UAV drone implementation.")
+    elif drone_type in WIFI_UAV_DRONE_TYPES:
+        wifi_uav_variant = resolve_wifi_uav_variant(drone_type)
+        logger.info("[main] Using WiFi UAV drone implementation (variant=%s).", wifi_uav_variant)
         # Align with previous working setup: env-configurable IP and ports
         default_ip = "192.168.169.1"
         default_ctrl_port = 8800
@@ -208,12 +210,13 @@ async def lifespan(app: FastAPI):
         video_port = int(os.getenv("VIDEO_PORT", default_video_port))
 
         model = WifiUavRcModel()
-        rc_proto = WifiUavRcProtocolAdapter(drone_ip, ctrl_port)
+        rc_proto = WifiUavRcProtocolAdapter(drone_ip, ctrl_port, variant=wifi_uav_variant)
         video_adapter_cls = WifiUavVideoProtocolAdapter
         video_adapter_args = {
             "drone_ip": drone_ip,
             "control_port": ctrl_port,
             "video_port": video_port,
+            "variant": wifi_uav_variant,
             "debug": False,
         }
     elif drone_type == "cooingdv":
@@ -251,7 +254,7 @@ async def lifespan(app: FastAPI):
         "protocol_adapter_args": video_adapter_args,
         "frame_queue": RAW_Q,
     }
-    if drone_type == "wifi_uav":
+    if drone_type in WIFI_UAV_DRONE_TYPES:
         video_service_args["rc_adapter"] = rc_proto
     
     receiver = VideoReceiverService(**video_service_args)

--- a/docs/research/wifi_uav.md
+++ b/docs/research/wifi_uav.md
@@ -1,0 +1,379 @@
+# WiFi-UAV Protocol Research
+
+This note captures findings from the decompiled WiFi-UAV Android app in
+`wifi-uav-app-decompiled` and from native analysis of
+`wifi-uav-app-decompiled/resources/lib/arm64-v8a/libuav_lib.so`.
+
+The main takeaway is that "WiFi-UAV" is a drone family, not one protocol.
+The app routes different SSID families to different backend SDKs.
+
+## App Backend Variants
+
+The app uses `defpackage.d00` as a dispatcher. It maps SSID prefixes onto two
+backend families:
+
+```java
+put("FlOW_", f.Uav);
+put("FLOW_", f.Uav);
+put("WIFI_", f.Fld);
+put("GD89Pro_", f.Fld);
+put("WTECH-", f.Fld);
+put("WTECH_", f.Fld);
+```
+
+The dispatcher then binds those backend enum values to concrete implementations:
+
+```java
+put(f.Fld, wz.X());
+put(f.Uav, e00.i0());
+```
+
+Observed / inferred mapping:
+
+| SSID prefix | App backend | Java class | Native dependency | Notes |
+| --- | --- | --- | --- | --- |
+| `WIFI_` | `Fld` | `defpackage.wz` | `com.lxProLib.lxSigPro` / `lxPro` | Classic WiFi-UAV path. |
+| `GD89Pro_` | `Fld` | `defpackage.wz` | `com.lxProLib.lxSigPro` / `lxPro` | Same backend as `WIFI_`. |
+| `WTECH-`, `WTECH_` | `Fld` | `defpackage.wz` | `com.lxProLib.lxSigPro` / `lxPro` | Same backend as `WIFI_`. |
+| `FLOW_`, `FlOW_` | `Uav` | `defpackage.e00` | `com.example.sdk.UAVSDK` / `libuav_lib.so` | Native UAVSDK backend. |
+| `DRONE_` | Not in app map | Turbodrone maps to `fld` | Appears K417-compatible with `fld` wire behavior | Added from K417 testing. |
+
+## Fld Backend
+
+`defpackage.wz` wraps `com.lxProLib.lxSigPro`:
+
+```java
+public class wz extends tz {
+    public lxSigPro d = lxSigPro.getInstance();
+}
+```
+
+Important methods:
+
+```java
+public int g() { return this.d.Connect(0); }
+public int h(byte[] bArr) { return this.d.DataForward(bArr, 0); }
+public int i() { return this.d.DisConnect(); }
+public int p() { return this.d.StPlay(0); }
+public int q() { return this.d.StStop(); }
+```
+
+Implications:
+
+- `Fld` has explicit connect / data-forward / disconnect / start-play /
+  stop-play lifecycle in the app.
+- Turbodrone does not call `lxSigPro`; it reconstructs the wire behavior in
+  Python.
+- K417 (`DRONE_*`) appears to use a wire path compatible with this family.
+
+## Uav / FLOW Backend
+
+`defpackage.e00` wraps `com.example.sdk.UAVSDK`:
+
+```java
+public class e00 extends tz implements UAVSDK.DataListener {
+    public UAVSDK f = UAVSDK.getInstance();
+}
+```
+
+Important methods:
+
+```java
+public int g() {
+    if (this.n) return 0;
+    this.n = true;
+    this.f.nativeStart();
+    return 0;
+}
+
+public int h(byte[] bArr) {
+    this.f.nativeSendCtlMsg(bArr, bArr.length);
+    return 0;
+}
+
+public int i() {
+    this.q = 0L;
+    this.h.f();
+    this.o = false;
+    this.p = true;
+    if (this.n) {
+        this.n = false;
+        this.f.nativeStop();
+    }
+    return 0;
+}
+```
+
+`UAVSDK` loads:
+
+```java
+System.loadLibrary("uav_lib");
+System.loadLibrary("upcnn-cpu");
+if (Build.VERSION.SDK_INT >= 24) {
+    System.loadLibrary("upcnn-gpu");
+}
+```
+
+`UAVSDK` exposes JNI methods including:
+
+```java
+nativeCreate();
+nativeDestroy();
+nativeGetVersion();
+nativeInit();
+nativeSendCtlMsg(byte[] data, int len);
+nativeSendCustomMsg(byte[] data, int len);
+nativeSetCameraIndex(int index);
+nativeSetCameraRotate180(int value);
+nativeSetQPara(int q1, int q2, int t1, int t2);
+nativeStart();
+nativeStop();
+```
+
+## Native UAVSDK Findings
+
+`libuav_lib.so` is an ARM64 ELF shared object. It is not stripped and contains
+debug info, so Ghidra headless analysis is useful.
+
+Exports of interest:
+
+- `Java_com_example_sdk_UAVSDK_nativeStart`
+- `Java_com_example_sdk_UAVSDK_nativeStop`
+- `Java_com_example_sdk_UAVSDK_nativeSendCtlMsg`
+- `Java_com_example_sdk_UAVSDK_nativeSendCustomMsg`
+- `mjpeg_ndk_start`
+- `mjpeg_ndk_stop`
+- `mjpeg_ndk_command_send`
+- `mjpeg_ndk_custom_cmd_send`
+- `mjpeg_ndk_start_bl618`
+- `mjpeg_ndk_stop_bl618`
+- `mjpeg_ndk_command_send_bl618`
+- `mjpeg_ndk_custom_cmd_send_bl618`
+- `handle_mcu_msg_frag`
+- `handle_mcu_msg_frag_bl618`
+- `build_send_ack`
+- `build_send_ack_bl618`
+
+### Native Start Behavior
+
+`nativeStart()` starts two internal native backends:
+
+```c
+context = mjpeg_ndk_start("192.168.169.1", "8800", NULL);
+mjpeg_ndk_frame_callback_register(context, callback_jpeg, context);
+mjpeg_ndk_ctlmsg_cb_register(context, callback_ctlmsg, context);
+mjpeg_ndk_track_set_sdk(context, sdk);
+mjpeg_ndk_track_callback_register(context, callback_track, context);
+
+context_bl618 = mjpeg_ndk_start_bl618(NULL, "192.168.169.1", "8801");
+mjpeg_ndk_frame_callback_register_bl618(context_bl618, callback_jpeg, context_bl618);
+mjpeg_ndk_ctlmsg_cb_register_bl618(context_bl618, callback_ctlmsg, context_bl618);
+mjpeg_ndk_track_set_sdk_bl618(context_bl618, sdk);
+mjpeg_ndk_track_callback_register_bl618(context_bl618, callback_track, context_bl618);
+```
+
+Implications:
+
+- Native UAVSDK probes both the normal path and the BL618 path.
+- Normal backend targets `192.168.169.1:8800`.
+- BL618 backend targets `192.168.169.1:8801`.
+- Turbodrone's `wifi_uav_uav` mode now mirrors this by sending RC and video
+  startup/request traffic to both ports.
+
+### Native Socket Setup
+
+Normal `create_instance()`:
+
+- creates an ACK/socket bound to `0.0.0.0` on an ephemeral local port
+- sets MCU target to `192.168.169.1:8800`
+- creates a side UDP socket using `NetworkSocket_Create(Network_UDP, 0x271a)`
+- `0x271a == 10010`
+
+BL618 `create_instance_bl618()`:
+
+- creates an ACK/socket bound to `0.0.0.0` on an ephemeral local port
+- sets MCU target to `192.168.169.1:8801`
+- creates a side UDP socket using `NetworkSocket_Create(Network_UDP, 0x271b)`
+- `0x271b == 10011`
+
+K417 captures showed video fragments arrive at the ephemeral ACK socket, not at
+`10010` or `10011`.
+
+### Native Startup Packet
+
+The startup packet is:
+
+```text
+ef 00 04 00
+```
+
+The BL618 startup path sends this repeatedly during startup.
+
+## Video Packet Format
+
+K417 captures and native `handle_mcu_msg_frag*()` agree on this layout:
+
+| Offset | Size | Meaning |
+| --- | ---: | --- |
+| `0` | 1 | `0x93` |
+| `1` | 1 | message type; `0x01` means JPEG fragment |
+| `2` | 2 | total packet length, little-endian |
+| `4` | 4 | message sequence / id |
+| `8` | 8 | image sequence |
+| `24` | 8 | last-finished / acked-ish sequence field |
+| `32` | 4 | fragment index |
+| `36` | 4 | fragment count |
+| `40` | 4 | frame body length |
+| `44` | 2 | width |
+| `46` | 2 | height |
+| `48` | 1 | quality |
+| `52` | 1 | main camera status |
+| `53` | 1 | flow camera status |
+| `56+` | var | JPEG payload fragment |
+
+Observed K417 traffic:
+
+- drone sends from `192.168.169.1:1234`
+- PC receives on the ephemeral socket used to send ACK/request packets
+- typical packet length: `1088` bytes
+- quality: `50`
+- about `10-19` fragments per frame
+- about `15 fps` in a working capture
+
+## ACK / Request Packet Format
+
+Native `build_send_ack()` and `build_send_ack_bl618()` emit this broad shape:
+
+| Offset | Size | Meaning |
+| --- | ---: | --- |
+| `0` | 1 | `0xef` |
+| `1` | 1 | `0x02` |
+| `2` | 2 | packet length, little-endian |
+| `4` | 4 | constant `02 02 00 01` |
+| `8` | 1 | ACK slot count |
+| `9` | 3 | padding |
+| `12` | 4 | queued user-command sequence |
+| `16` | 2 | queued user-command length |
+| `18` | 64 | queued user-command data |
+| `82` | 1 | quality1 |
+| `83` | 1 | quality2 |
+| `84` | 1 | q_threshold1 |
+| `85` | 1 | q_threshold2 |
+| `86` | 1 | active camera index |
+| `87` | 1 | padding |
+| `88+` | var | ACK slot records |
+
+Each ACK slot:
+
+| Offset | Size | Meaning |
+| --- | ---: | --- |
+| `0` | 8 | image sequence |
+| `8` | 4 | status |
+| `12` | 4 | slot record length |
+| `16+` | var | optional fragment ACK bitmap |
+
+Status values inferred from native:
+
+- `0`: receiving / partial
+- `1`: complete / delivered
+- `2`: dropped
+- `3`: future/request slot
+
+Turbodrone now generates native-shaped ACK packets and tracks in-flight frame
+state using `WifiUavAckState`.
+
+## Control Packet Semantics
+
+The app has two control builders:
+
+- `xx.f()` short 8-byte layout
+- `xx.g()` extended 20-byte layout
+
+Turbodrone embeds the extended layout (`66 14 ...`) in the longer `ef 02 ...`
+packet wrapper.
+
+In `xx.g()`, takeoff and land share the same one-key bit:
+
+```java
+bArr[6] = (takeoff ? 1 : 0)
+        | (land    ? 1 : 0)
+        | (stop    ? 2 : 0)
+        | (gyro    ? 4 : 0)
+        | (roll    ? 8 : 0)
+        | ((ptz & 3) << 6);
+```
+
+Meaning for Turbodrone's current WiFi-UAV extended command layout:
+
+| Action | Byte 6 bit |
+| --- | ---: |
+| takeoff / land one-key action | `0x01` |
+| emergency stop | `0x02` |
+| gyro/calibration | `0x04` |
+| flip/roll | `0x08` |
+
+K417 testing confirmed:
+
+- app land button descends gracefully
+- Turbodrone previously mapped land to `0x02`, causing motor cutoff
+- Turbodrone now maps both takeoff and land to `0x01`, and e-stop to `0x02`
+
+## K417 Notes
+
+Observed K417 SSID:
+
+```text
+DRONE_4C8172
+```
+
+This prefix is not present in the decompiled app's dispatcher, but testing shows
+it is compatible with the `fld`-style wire path:
+
+```env
+DRONE_TYPE=wifi_uav_fld
+```
+
+Working capture summary:
+
+- inbound: `192.168.169.1:1234 -> 192.168.169.2:<ephemeral>`
+- outbound: `<ephemeral> -> 192.168.169.1:8800`
+- `4527` video packets in about `20s`
+- `295` frame sequences
+- `294` complete frames
+- approximately `15 fps`
+
+Windows Firewall can block inbound video because the drone replies from UDP
+source port `1234`, not from `8800`. Packet capture may show traffic even if
+Python does not receive it. During testing, disabling firewall allowed Python
+to receive and assemble frames.
+
+## Turbodrone Implementation State
+
+Current related files:
+
+- `backend/protocols/wifi_uav_rc_protocol_adapter.py`
+- `backend/protocols/wifi_uav_video_protocol.py`
+- `backend/utils/wifi_uav_packets.py`
+- `backend/utils/wifi_uav_ack_state.py`
+- `backend/utils/wifi_uav_variants.py`
+
+Implemented:
+
+- `DRONE_TYPE=wifi_uav`, `wifi_uav_fld`, `wifi_uav_uav`
+- best-effort SSID mapping
+- `DRONE_` maps to `fld`
+- `wifi_uav_uav` probes `8800` and `8801`
+- corrected WiFi-UAV extended land/e-stop semantics
+- native-shaped ACK/request packet builder
+- native fragment parser
+- ACK state tracking
+- duplicate delivered-frame guard
+- startup/request burst moved after RX thread startup
+
+Remaining possible work:
+
+- Full native four-slot state machine parity, if needed.
+- More `wifi_uav_uav` / FLOW hardware testing.
+- Proper Windows firewall documentation or setup helper.
+- Frontend capability refinement: WiFi-UAV takeoff/land is really one-key
+  takeoff/land, not independent commands.


### PR DESCRIPTION
- "Land" button now implemented correctly.
- "E-Stop" mapped.
- Video feed improvements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WiFi-UAV RC/video protocol logic (packet flags, ACK generation, reconnection, and multi-port probing), so regressions could break control or video streaming on affected drones.
> 
> **Overview**
> Extends WiFi-UAV support to handle multiple backend *variants* (new `wifi_uav_fld`/`wifi_uav_uav` options plus SSID-based auto-detection) and plumbs the resolved `variant` through CLI and web server startup.
> 
> Fixes WiFi-UAV control semantics by mapping **takeoff+land to the same one-key bit** and mapping **e-stop to its own bit**, and for the UAV/FLOW variant probes/sends RC+video traffic to both `8800` and `8801`.
> 
> Reworks WiFi-UAV video request/assembly to use **native-shaped ACK/request packets** with a new `WifiUavAckState` tracker, adds stricter fragment parsing with legacy fallback, improves startup/warmup ordering, and adds link-stall detection to force adapter restart when streaming stops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 272b77a61449dbcecc1d5a3b69d8e97de6bd12ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->